### PR TITLE
Chore: start analyzer doc with a capital letter

### DIFF
--- a/untypedconst.go
+++ b/untypedconst.go
@@ -16,7 +16,7 @@ import (
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "untypedconst",
-	Doc:      "checks that untyped constant expressions are used as a values of defined type",
+	Doc:      "Checks that untyped constant expressions are used as values of a defined type",
 	Run:      run,
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 }


### PR DESCRIPTION
For consistency with other golangci-lint [linters](https://golangci-lint.run/usage/linters/).