### PR TITLE
Add checks for comparisons of  "untyped consts against defined typed expressions in conditionals

### DIFF
--- a/testdata/src/ifstmt/ifstmt.go
+++ b/testdata/src/ifstmt/ifstmt.go
@@ -1,0 +1,23 @@
+package ifstmt
+
+import "github.com/jiftechnify/untypedconst/pkg/external"
+
+func IfStmt(i int, j int, exInt external.ExInt) {
+	if i == 0 {
+	}
+	if exInt == external.ExInt(0) {
+	}
+	if exInt == 0 { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+	if 0 <= exInt { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+
+	if i == 0 && exInt == external.ExInt(0) {
+	}
+	if exInt == 0 && i == 0 { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+	if i == 0 || exInt == 0 { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+	if i == 0 || (j == 0 && exInt == 0) { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+}

--- a/testdata/src/ifstmt/ifstmt.go
+++ b/testdata/src/ifstmt/ifstmt.go
@@ -21,3 +21,57 @@ func IfStmt(i int, j int, exInt external.ExInt) {
 	if i == 0 || (j == 0 && exInt == 0) { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
 	}
 }
+
+func genInt() int {
+	return 0
+}
+
+func genExInt() external.ExInt {
+	return external.ExInt(0)
+}
+
+func IfStmtFuncCall() {
+	if genInt() == 0 {
+	}
+	if genExInt() == external.ExInt(0) {
+	}
+	if genExInt() == 0 { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+	if 0 <= genExInt() { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+}
+
+type foo struct {
+	i     int
+	exInt external.ExInt
+}
+
+func (f *foo) getI() int {
+	return f.i
+}
+
+func (f *foo) getExInt() external.ExInt {
+	return f.exInt
+}
+
+func IfStmtSelector(f *foo) {
+	if f.i == 0 {
+	}
+	if f.exInt == external.ExInt(0) {
+	}
+	if f.exInt == 0 { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+	if 0 <= f.exInt { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+}
+
+func IfStmtMethodCall(f *foo) {
+	if f.getI() == 0 {
+	}
+	if f.getExInt() == external.ExInt(0) {
+	}
+	if f.getExInt() == 0 { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+	if 0 <= f.getExInt() { // want `comparing untyped constant to expression of defined type "github.com/jiftechnify/untypedconst/pkg/external.ExInt"`
+	}
+}

--- a/testdata/src/switchstmt/switchstmt.go
+++ b/testdata/src/switchstmt/switchstmt.go
@@ -7,20 +7,77 @@ const (
 	One  ZeroOne = 1
 )
 
-func SwitchStmt(i int, zo ZeroOne) {
+func SwitchStmt(i int, zeroOne ZeroOne) {
 	switch i {
 	case 0:
 	case 1:
 	default:
 	}
 
-	switch zo {
+	switch zeroOne {
 	case Zero:
 	case ZeroOne(1):
 	default:
 	}
 
-	switch zo {
+	switch zeroOne {
+	case 0: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
+	case 1: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
+	default:
+	}
+}
+
+func genZeroOne(b bool) ZeroOne {
+	if b {
+		return One
+	}
+	return Zero
+}
+
+func SwitchStmtFuncCall(b bool) {
+	switch genZeroOne(b) {
+	case Zero:
+	case ZeroOne(1):
+	default:
+	}
+
+	switch genZeroOne(b) {
+	case 0: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
+	case 1: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
+	default:
+	}
+}
+
+type foo struct {
+	zeroOne ZeroOne
+}
+
+func (f *foo) getZeroOne() ZeroOne {
+	return f.zeroOne
+}
+
+func SwitchStmtSelector(f *foo) {
+	switch f.getZeroOne() {
+	case Zero:
+	case ZeroOne(1):
+	default:
+	}
+
+	switch f.getZeroOne() {
+	case 0: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
+	case 1: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
+	default:
+	}
+}
+
+func SwitchStmtMethodCall(f *foo) {
+	switch f.getZeroOne() {
+	case Zero:
+	case ZeroOne(1):
+	default:
+	}
+
+	switch f.getZeroOne() {
 	case 0: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
 	case 1: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
 	default:

--- a/testdata/src/switchstmt/switchstmt.go
+++ b/testdata/src/switchstmt/switchstmt.go
@@ -1,0 +1,28 @@
+package switchstmt
+
+type ZeroOne int
+
+const (
+	Zero ZeroOne = 0
+	One  ZeroOne = 1
+)
+
+func SwitchStmt(i int, zo ZeroOne) {
+	switch i {
+	case 0:
+	case 1:
+	default:
+	}
+
+	switch zo {
+	case Zero:
+	case ZeroOne(1):
+	default:
+	}
+
+	switch zo {
+	case 0: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
+	case 1: // want `matching untyped constant with expression of defined type "switchstmt.ZeroOne"`
+	default:
+	}
+}

--- a/untypedconst_test.go
+++ b/untypedconst_test.go
@@ -7,7 +7,19 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
+var pkgs = []string{
+	"github.com/...",
+	"callexpr",
+	"sendstmt",
+	"returnstmt",
+	"compositelit",
+	"indexexpr",
+	"gendecl",
+	"ifstmt",
+	"switchstmt",
+}
+
 func TestAll(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, untypedconst.Analyzer, "github.com/...", "callexpr", "sendstmt", "returnstmt", "compositelit", "indexexpr", "gendecl")
+	analysistest.Run(t, testdata, untypedconst.Analyzer, pkgs...)
 }


### PR DESCRIPTION
- For all comparisons(`==`, `<` etc.) in a `if` statement's condition, check whether an untyped const is compared to a defined typed expr
  - Ignores such comparisons outside of `if` for now
- For a `switch` statement, check whether an untyped const is matched with a scrutinee("tag" in Go lang spec) of defined type